### PR TITLE
feat: add query_comment support, slim down query tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,13 +195,18 @@ query-comment:
 
 ## Upgrading from v1.x
 
-Version 2.0 introduces query comments as the primary metadata carrier. The key change:
+Version 2.0 introduces query comments as the primary metadata carrier. Breaking changes:
 
-1. **Add `query-comment` to your `dbt_project.yml`** (new requirement)
-2. **Query tags are now lean** — comprehensive metadata moved to query comments
+1. **Add `query-comment` to your `dbt_project.yml`** (new requirement — this is where all metadata now lives)
+2. **Query tags are now lean** — only session-level keys (`dbt_integration_id`, `dbt_integration_environment`) plus `is_incremental` remain in the query tag. All other metadata moved to query comments.
 3. **`unset_query_tag` macro added** — properly restores session state after model execution
+4. **`extra` parameter removed from `set_query_tag`** — if you were passing custom fields via `set_query_tag(extra={...})`, move them to `get_query_comment(node, extra={...})` in your `query-comment` config instead.
+5. **`env_vars_to_query_tag_list` variable removed** — environment variables are no longer added to query tags. They can be added to query comments via the `extra` parameter.
+6. **`thread_id` removed from query tags** — thread information is no longer included. If needed, add it via `extra` in `get_query_comment`.
 
 The `dbt_integration_id` and `dbt_integration_environment` fields remain in the query tag for backward compatibility with Altimate extractors.
+
+> **Note on query comment size:** While query comments have no enforced character limit, Snowflake's `QUERY_TEXT` column has a 100KB limit. Keep `node_meta` and `node_tags` reasonable to avoid truncation in query history.
 
 ---
 
@@ -210,13 +215,23 @@ The `dbt_integration_id` and `dbt_integration_environment` fields remain in the 
 After running `dbt run`, verify both mechanisms:
 
 ```sql
--- Check query comments (visible in QUERY_TEXT or via query profile)
+-- Check via query tag
 SELECT
     query_id,
     query_text,
     query_tag
 FROM snowflake.account_usage.query_history
 WHERE query_tag LIKE '%dbt_integration_id%'
+ORDER BY start_time DESC
+LIMIT 10;
+
+-- Check via query comment content
+SELECT
+    query_id,
+    query_text,
+    query_tag
+FROM snowflake.account_usage.query_history
+WHERE query_text LIKE '%dbt_snowflake_query_tags_version%'
 ORDER BY start_time DESC
 LIMIT 10;
 ```

--- a/README.md
+++ b/README.md
@@ -1,29 +1,31 @@
 # Altimate dbt Query Tags
 
-This guide will help you set up query tags in **snowflake** to identify your dbt workloads executed in both **dbt Core** and **dbt Cloud** environments.
+This package enriches your Snowflake dbt workloads with comprehensive metadata using **two complementary mechanisms**:
+
+- **Query Comments**: Rich metadata appended to every SQL statement (no character limit)
+- **Query Tags**: Lean session-level tags for quick identification (respects Snowflake's 2000-character limit)
+
+This dual approach solves the common problem of query tags exceeding Snowflake's 2000-character limit while preserving all metadata in query comments.
 
 ---
 
-## 🔧 Step 1: Initial Setup
+## Step 1: Initial Setup
 
 ### Create dbt Integration and Environment
 
-1. Navigate to **Settings** → **Integrations** in the UI
+1. Navigate to **Settings** > **Integrations** in the UI
 2. Click **"Create New Integration"** and select **dbt Integration**
 3. Create a new **dbt Environment** for your project
 
 ---
 
-## 🧩 dbt Core Setup
-
-Follow these steps to configure query tags in your dbt Core project:
+## dbt Core Setup
 
 ### 1. Add Query Tag to `profiles.yml`
 
-Add the query tag configuration to your `profiles.yml` file (typically located in `~/.dbt/profiles.yml`). Replace the values with your actual integration ID and environment name. You can get the values from the SaaS UI under Settings -> Integrations:
+Add the query tag configuration to your `profiles.yml` file (typically located in `~/.dbt/profiles.yml`). Replace the values with your actual integration ID and environment name from the SaaS UI under Settings -> Integrations:
 
 ```yaml
-# Example profiles.yml configuration
 my_profile:
   outputs:
     prod:
@@ -35,7 +37,6 @@ my_profile:
       schema: your_schema
       user: your_username
       password: your_password
-# ... other connection parameters
     dev:
       query_tag: '{"dbt_integration_id": 1, "dbt_integration_environment": "DEV"}'
       type: snowflake
@@ -48,19 +49,7 @@ my_profile:
   target: prod
 ```
 
-Your `dbt_project.yml` should reference this profile:
-
-```yaml
-name: 'my_project'
-version: '1.0.0'
-profile: 'my_profile'  # This should match the profile name in profiles.yml
-
-models:
-  my_project:
-    # Your model configurations here
-```
-
-> ⚠️ Important: Make sure the query_tag which is set in the project is in valid JSON format.
+> **Important:** The `query_tag` must be valid JSON.
 
 ### 2. Update `packages.yml`
 
@@ -68,18 +57,25 @@ Create or update your `packages.yml` file to include the Altimate query tags pac
 
 ```yaml
 packages:
-  - git: "https://github.com/AltimateAI/altimate-dbt-query-tags.git"
+  - git: "https://github.com/AltimateAI/altimate-dbt-snowflake-query-tags.git"
+    revision: main
 
   # Your other packages
   - package: dbt-labs/dbt_utils
     version: 1.1.1
 ```
 
-### 3. Configure Dispatch in `dbt_project.yml`
+### 3. Configure `dbt_project.yml`
 
-Add the dispatch configuration to ensure the query tag macros are properly loaded:
+Add the dispatch and query-comment configurations:
 
 ```yaml
+# Enable query comments — comprehensive metadata appended to every SQL statement
+query-comment:
+  comment: '{{ altimate_snowflake_query_tags.get_query_comment(node) }}'
+  append: true
+
+# Enable query tags — lean session-level tags via dispatch
 dispatch:
   - macro_namespace: dbt
     search_order:
@@ -88,35 +84,141 @@ dispatch:
       - dbt
 ```
 
-> 📝 Note: Replace YOUR_PROJECT_NAME with the actual name of your dbt project (the name field in your dbt_project.yml).
+> **Note:** `append: true` is required because Snowflake strips leading SQL comments. Appending ensures the comment is preserved.
 
-## ☁️ dbt Cloud Setup
+### 4. Run `dbt deps`
 
-For dbt Cloud users, follow these steps:
+Install the package:
+
+```bash
+dbt deps
+```
+
+---
+
+## dbt Cloud Setup
 
 ### 1. Configure Cloud Profile
 
 1. Navigate to your **dbt Cloud Project Settings**
-2. Go to **Connection** → **Extended Attributes**
+2. Go to **Connection** > **Extended Attributes**
+3. Add the `query_tag` JSON with your integration ID and environment
 
 ### 2. Update `packages.yml`
 
-Add the query tags package to your dbt Cloud project:
-
 ```yaml
 packages:
-  - git: "https://github.com/AltimateAI/altimate-dbt-query-tags.git"
+  - git: "https://github.com/AltimateAI/altimate-dbt-snowflake-query-tags.git"
+    revision: main
 ```
 
 ### 3. Configure `dbt_project.yml`
 
-Update your dispatch configuration:
-
 ```yaml
+query-comment:
+  comment: '{{ altimate_snowflake_query_tags.get_query_comment(node) }}'
+  append: true
+
 dispatch:
   - macro_namespace: dbt
     search_order:
-      - YOUR_PROJECT_NAME  # Your dbt Cloud project name
+      - YOUR_PROJECT_NAME
       - altimate_snowflake_query_tags
       - dbt
 ```
+
+---
+
+## What Gets Captured
+
+### Query Comment (appended to SQL)
+
+The query comment contains comprehensive metadata with no character limit:
+
+| Field | Description |
+|---|---|
+| `app` | Always `"dbt"` |
+| `dbt_snowflake_query_tags_version` | Package version |
+| `dbt_version` | dbt version |
+| `project_name` | dbt project name |
+| `target_name` | Target environment name |
+| `target_database` | Target database |
+| `target_schema` | Target schema |
+| `invocation_id` | Unique run identifier |
+| `run_started_at` | Run start timestamp (UTC ISO format) |
+| `full_refresh` | Whether this is a full refresh run |
+| `node_name` | Model/test/seed name |
+| `node_alias` | Node alias |
+| `node_package_name` | Package the node belongs to |
+| `node_original_file_path` | Source file path |
+| `node_database` | Node's target database |
+| `node_schema` | Node's target schema |
+| `node_id` | Unique node identifier |
+| `node_resource_type` | Type (model, test, seed, etc.) |
+| `node_meta` | Custom metadata from schema.yml |
+| `node_tags` | Tags assigned to the node |
+| `node_refs` | Referenced models |
+| `materialized` | Materialization strategy (models only) |
+| `raw_code_hash` | MD5 hash of model code |
+| `dbt_cloud_*` | dbt Cloud metadata (when available) |
+
+### Query Tag (session-level)
+
+The query tag is kept lean to stay within Snowflake's 2000-character limit:
+
+| Field | Description |
+|---|---|
+| `dbt_integration_id` | Altimate integration identifier (from `profiles.yml`) |
+| `dbt_integration_environment` | Environment (PROD, DEV, etc.) (from `profiles.yml`) |
+| `is_incremental` | Whether running incrementally (models only) |
+
+The query tag preserves all session-level keys set in `profiles.yml` and adds only `is_incremental` — which is only available at execution time and cannot be captured in query comments.
+
+---
+
+## Customization
+
+### Add Custom Fields to Query Comments
+
+```yaml
+# dbt_project.yml
+query-comment:
+  comment: >
+    {{ altimate_snowflake_query_tags.get_query_comment(
+      node,
+      extra={'team': 'data-platform', 'slack_channel': '#data-alerts'}
+    ) }}
+  append: true
+```
+
+---
+
+## Upgrading from v1.x
+
+Version 2.0 introduces query comments as the primary metadata carrier. The key change:
+
+1. **Add `query-comment` to your `dbt_project.yml`** (new requirement)
+2. **Query tags are now lean** — comprehensive metadata moved to query comments
+3. **`unset_query_tag` macro added** — properly restores session state after model execution
+
+The `dbt_integration_id` and `dbt_integration_environment` fields remain in the query tag for backward compatibility with Altimate extractors.
+
+---
+
+## Verifying in Snowflake
+
+After running `dbt run`, verify both mechanisms:
+
+```sql
+-- Check query comments (visible in QUERY_TEXT or via query profile)
+SELECT
+    query_id,
+    query_text,
+    query_tag
+FROM snowflake.account_usage.query_history
+WHERE query_tag LIKE '%dbt_integration_id%'
+ORDER BY start_time DESC
+LIMIT 10;
+```
+
+The query comment appears appended to the SQL statement. The query tag appears in the `QUERY_TAG` column.

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,3 +1,4 @@
 name: 'altimate_snowflake_query_tags'
 version: '2.0.0'
 config-version: 2
+require-dbt-version: ">=1.5.0"

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,3 +1,3 @@
 name: 'altimate_snowflake_query_tags'
-version: '1.0.2'
+version: '2.0.0'
 config-version: 2

--- a/macros/query_comment.sql
+++ b/macros/query_comment.sql
@@ -14,8 +14,13 @@
         target_schema=target.schema,
         invocation_id=invocation_id,
         run_started_at=run_started_at.isoformat(),
-        full_refresh=flags.FULL_REFRESH
+        full_refresh=flags.FULL_REFRESH,
+        which=flags.WHICH
     ) -%}
+
+    {%- if flags.INVOCATION_COMMAND is defined and flags.INVOCATION_COMMAND -%}
+        {%- do comment_dict.update(invocation_command=flags.INVOCATION_COMMAND) -%}
+    {%- endif -%}
 
     {# Add node-specific information if available #}
     {%- if node is not none -%}

--- a/macros/query_comment.sql
+++ b/macros/query_comment.sql
@@ -1,5 +1,6 @@
 {% macro get_query_comment(node, extra = {}) %}
-    {%- set comment_dict = extra -%}
+    {%- set comment_dict = {} -%}
+    {%- do comment_dict.update(extra) -%}
 
     {# Add standard dbt information #}
     {%- do comment_dict.update(
@@ -11,7 +12,7 @@
         target_database=target.database,
         target_schema=target.schema,
         invocation_id=invocation_id,
-        run_started_at=run_started_at.astimezone(modules.pytz.utc).isoformat(),
+        run_started_at=run_started_at.isoformat(),
         full_refresh=flags.FULL_REFRESH
     ) -%}
 
@@ -26,11 +27,14 @@
             node_schema=node.schema,
             node_id=node.unique_id,
             node_resource_type=node.resource_type,
-            node_meta=node.config.meta,
             node_tags=node.tags
         ) -%}
 
-        {%- if node.resource_type == 'model' -%}
+        {%- if node.config is defined and node.config.meta is defined -%}
+            {%- do comment_dict.update(node_meta=node.config.meta) -%}
+        {%- endif -%}
+
+        {%- if node.resource_type == 'model' and node.config is defined -%}
             {%- do comment_dict.update(materialized=node.config.materialized) -%}
         {%- endif -%}
 
@@ -42,31 +46,33 @@
                     {%- do refs.append(ref.name) -%}
                 {%- elif ref is iterable and ref is not string -%}
                     {%- do refs.append(ref[0]) -%}
+                {%- else -%}
+                    {%- do refs.append(ref | string) -%}
                 {%- endif -%}
             {% endfor %}
             {%- do comment_dict.update(node_refs=refs | unique | list) -%}
         {%- endif -%}
 
         {# Add raw code hash for change detection #}
-        {%- if node.raw_code is not none and local_md5 -%}
+        {%- if node.raw_code is not none and local_md5 is defined -%}
             {%- do comment_dict.update(raw_code_hash=local_md5(node.raw_code)) -%}
         {%- endif -%}
     {%- endif -%}
 
     {# Add dbt Cloud information if available #}
-    {%- if env_var('DBT_CLOUD_PROJECT_ID', False) -%}
+    {%- if env_var('DBT_CLOUD_PROJECT_ID', '') -%}
         {%- do comment_dict.update(dbt_cloud_project_id=env_var('DBT_CLOUD_PROJECT_ID')) -%}
     {%- endif -%}
-    {%- if env_var('DBT_CLOUD_JOB_ID', False) -%}
+    {%- if env_var('DBT_CLOUD_JOB_ID', '') -%}
         {%- do comment_dict.update(dbt_cloud_job_id=env_var('DBT_CLOUD_JOB_ID')) -%}
     {%- endif -%}
-    {%- if env_var('DBT_CLOUD_RUN_ID', False) -%}
+    {%- if env_var('DBT_CLOUD_RUN_ID', '') -%}
         {%- do comment_dict.update(dbt_cloud_run_id=env_var('DBT_CLOUD_RUN_ID')) -%}
     {%- endif -%}
-    {%- if env_var('DBT_CLOUD_RUN_REASON_CATEGORY', False) -%}
+    {%- if env_var('DBT_CLOUD_RUN_REASON_CATEGORY', '') -%}
         {%- do comment_dict.update(dbt_cloud_run_reason_category=env_var('DBT_CLOUD_RUN_REASON_CATEGORY')) -%}
     {%- endif -%}
-    {%- if env_var('DBT_CLOUD_RUN_REASON', False) -%}
+    {%- if env_var('DBT_CLOUD_RUN_REASON', '') -%}
         {%- do comment_dict.update(dbt_cloud_run_reason=env_var('DBT_CLOUD_RUN_REASON')) -%}
     {%- endif -%}
 

--- a/macros/query_comment.sql
+++ b/macros/query_comment.sql
@@ -3,9 +3,10 @@
     {%- do comment_dict.update(extra) -%}
 
     {# Add standard dbt information #}
+    {# run_started_at is already UTC-aware in dbt, no explicit timezone conversion needed #}
     {%- do comment_dict.update(
         app='dbt',
-        dbt_snowflake_query_tags_version='2.0.0',
+        dbt_snowflake_query_tags_version=var('dbt_snowflake_query_tags_version', '2.0.0'),
         dbt_version=dbt_version,
         project_name=project_name,
         target_name=target.name,
@@ -45,7 +46,8 @@
                 {%- if ref.name is defined -%}
                     {%- do refs.append(ref.name) -%}
                 {%- elif ref is iterable and ref is not string -%}
-                    {%- do refs.append(ref[0]) -%}
+                    {# ref[-1] handles two-part refs like ref('package', 'model') #}
+                    {%- do refs.append(ref[-1]) -%}
                 {%- else -%}
                     {%- do refs.append(ref | string) -%}
                 {%- endif -%}
@@ -76,6 +78,8 @@
         {%- do comment_dict.update(dbt_cloud_run_reason=env_var('DBT_CLOUD_RUN_REASON')) -%}
     {%- endif -%}
 
-    {# Sanitize */ which is illegal in SQL block comments and causes dbt to error #}
+    {# Sanitize */ which is illegal in SQL block comments and causes dbt to error.
+       This makes the JSON technically invalid if a value contained */, but this is
+       an acceptable trade-off vs breaking every SQL statement in the run. #}
     {{ return(tojson(comment_dict) | replace("*/", "* /")) }}
 {% endmacro %}

--- a/macros/query_comment.sql
+++ b/macros/query_comment.sql
@@ -42,7 +42,7 @@
         {%- if node.resource_type != 'seed' and node.refs is defined -%}
             {% set refs = [] %}
             {% for ref in node.refs %}
-                {%- if ref is mapping -%}
+                {%- if ref.name is defined -%}
                     {%- do refs.append(ref.name) -%}
                 {%- elif ref is iterable and ref is not string -%}
                     {%- do refs.append(ref[0]) -%}

--- a/macros/query_comment.sql
+++ b/macros/query_comment.sql
@@ -76,5 +76,6 @@
         {%- do comment_dict.update(dbt_cloud_run_reason=env_var('DBT_CLOUD_RUN_REASON')) -%}
     {%- endif -%}
 
-    {{ return(tojson(comment_dict)) }}
+    {# Sanitize */ which is illegal in SQL block comments and causes dbt to error #}
+    {{ return(tojson(comment_dict) | replace("*/", "* /")) }}
 {% endmacro %}

--- a/macros/query_comment.sql
+++ b/macros/query_comment.sql
@@ -83,8 +83,6 @@
         {%- do comment_dict.update(dbt_cloud_run_reason=env_var('DBT_CLOUD_RUN_REASON')) -%}
     {%- endif -%}
 
-    {# Sanitize */ which is illegal in SQL block comments and causes dbt to error.
-       This makes the JSON technically invalid if a value contained */, but this is
-       an acceptable trade-off vs breaking every SQL statement in the run. #}
-    {{ return(tojson(comment_dict) | replace("*/", "* /")) }}
+    {# Sanitize: */ breaks SQL block comments, null bytes cause driver errors #}
+    {{ return(tojson(comment_dict) | replace("*/", "* /") | replace("\x00", "")) }}
 {% endmacro %}

--- a/macros/query_comment.sql
+++ b/macros/query_comment.sql
@@ -1,0 +1,74 @@
+{% macro get_query_comment(node, extra = {}) %}
+    {%- set comment_dict = extra -%}
+
+    {# Add standard dbt information #}
+    {%- do comment_dict.update(
+        app='dbt',
+        dbt_snowflake_query_tags_version='2.0.0',
+        dbt_version=dbt_version,
+        project_name=project_name,
+        target_name=target.name,
+        target_database=target.database,
+        target_schema=target.schema,
+        invocation_id=invocation_id,
+        run_started_at=run_started_at.astimezone(modules.pytz.utc).isoformat(),
+        full_refresh=flags.FULL_REFRESH
+    ) -%}
+
+    {# Add node-specific information if available #}
+    {%- if node is not none -%}
+        {%- do comment_dict.update(
+            node_name=node.name,
+            node_alias=node.alias,
+            node_package_name=node.package_name,
+            node_original_file_path=node.original_file_path,
+            node_database=node.database,
+            node_schema=node.schema,
+            node_id=node.unique_id,
+            node_resource_type=node.resource_type,
+            node_meta=node.config.meta,
+            node_tags=node.tags
+        ) -%}
+
+        {%- if node.resource_type == 'model' -%}
+            {%- do comment_dict.update(materialized=node.config.materialized) -%}
+        {%- endif -%}
+
+        {# Add node references — skip for seeds to avoid dbt dependency detection #}
+        {%- if node.resource_type != 'seed' and node.refs is defined -%}
+            {% set refs = [] %}
+            {% for ref in node.refs %}
+                {%- if ref is mapping -%}
+                    {%- do refs.append(ref.name) -%}
+                {%- elif ref is iterable and ref is not string -%}
+                    {%- do refs.append(ref[0]) -%}
+                {%- endif -%}
+            {% endfor %}
+            {%- do comment_dict.update(node_refs=refs | unique | list) -%}
+        {%- endif -%}
+
+        {# Add raw code hash for change detection #}
+        {%- if node.raw_code is not none and local_md5 -%}
+            {%- do comment_dict.update(raw_code_hash=local_md5(node.raw_code)) -%}
+        {%- endif -%}
+    {%- endif -%}
+
+    {# Add dbt Cloud information if available #}
+    {%- if env_var('DBT_CLOUD_PROJECT_ID', False) -%}
+        {%- do comment_dict.update(dbt_cloud_project_id=env_var('DBT_CLOUD_PROJECT_ID')) -%}
+    {%- endif -%}
+    {%- if env_var('DBT_CLOUD_JOB_ID', False) -%}
+        {%- do comment_dict.update(dbt_cloud_job_id=env_var('DBT_CLOUD_JOB_ID')) -%}
+    {%- endif -%}
+    {%- if env_var('DBT_CLOUD_RUN_ID', False) -%}
+        {%- do comment_dict.update(dbt_cloud_run_id=env_var('DBT_CLOUD_RUN_ID')) -%}
+    {%- endif -%}
+    {%- if env_var('DBT_CLOUD_RUN_REASON_CATEGORY', False) -%}
+        {%- do comment_dict.update(dbt_cloud_run_reason_category=env_var('DBT_CLOUD_RUN_REASON_CATEGORY')) -%}
+    {%- endif -%}
+    {%- if env_var('DBT_CLOUD_RUN_REASON', False) -%}
+        {%- do comment_dict.update(dbt_cloud_run_reason=env_var('DBT_CLOUD_RUN_REASON')) -%}
+    {%- endif -%}
+
+    {{ return(tojson(comment_dict)) }}
+{% endmacro %}

--- a/macros/set_query_tag.sql
+++ b/macros/set_query_tag.sql
@@ -1,4 +1,4 @@
-{% macro default__set_query_tag(extra = {}) -%}
+{% macro default__set_query_tag() -%}
     {# Get session level query tag set via profiles.yml #}
     {% set original_query_tag = get_current_query_tag() %}
     {% set original_query_tag_parsed = {} %}
@@ -12,8 +12,8 @@
     {% set query_tag = original_query_tag_parsed %}
 
     {# is_incremental is only available at execution time, not in the query comment context #}
-    {# Guard with execute to prevent dbt parser from flagging seed hooks as node dependencies #}
-    {% if execute and model is not none and model.resource_type == 'model' %}
+    {# Guard with execute and defined checks for seed/run-operation compatibility #}
+    {% if execute and model is defined and model is not none and model.resource_type == 'model' %}
         {% do query_tag.update(is_incremental=is_incremental()) %}
     {% endif %}
 
@@ -23,12 +23,14 @@
     {% if query_tag_json and query_tag_json|length > 2000 %}
         {% do log("altimate-query-tag-warning: The constructed query tag is too long ({} characters). Snowflake limits query tags to 2000 characters, so the original query tag will be preserved instead.".format(query_tag_json|length), True) %}
         {% if original_query_tag %}
-            {% do run_query("alter session set query_tag = '{}'".format(original_query_tag)) %}
+            {% set safe_tag = original_query_tag | replace("'", "''") %}
+            {% do run_query("alter session set query_tag = '{}'".format(safe_tag)) %}
         {% else %}
             {% do run_query("alter session set query_tag = ''") %}
         {% endif %}
     {% else %}
-        {% do run_query("alter session set query_tag = '{}'".format(query_tag_json)) %}
+        {% set safe_tag = query_tag_json | replace("'", "''") %}
+        {% do run_query("alter session set query_tag = '{}'".format(safe_tag)) %}
     {% endif %}
 
     {{ return(original_query_tag) }}

--- a/macros/set_query_tag.sql
+++ b/macros/set_query_tag.sql
@@ -1,4 +1,4 @@
-{% macro default__set_query_tag() -%}
+{% macro default__set_query_tag(extra = {}) -%}
     {# Get session level query tag set via profiles.yml #}
     {% set original_query_tag = get_current_query_tag() %}
     {% set original_query_tag_parsed = {} %}
@@ -10,6 +10,16 @@
 
     {# Start with session-level query tag (preserves dbt_integration_id, dbt_integration_environment, etc.) #}
     {% set query_tag = original_query_tag_parsed %}
+
+    {# Merge any custom fields passed via extra #}
+    {% if extra is mapping %}
+        {% do query_tag.update(extra) %}
+    {% endif %}
+
+    {# Add thread_id for debugging concurrent runs #}
+    {% if thread_id is defined and thread_id %}
+        {% do query_tag.update(thread_id=thread_id) %}
+    {% endif %}
 
     {# is_incremental is only available at execution time, not in the query comment context #}
     {# Guard with execute and defined checks for seed/run-operation compatibility #}

--- a/macros/set_query_tag.sql
+++ b/macros/set_query_tag.sql
@@ -1,5 +1,5 @@
 {% macro default__set_query_tag(extra = {}) -%}
-    {# Get session level query tag #}
+    {# Get session level query tag set via profiles.yml #}
     {% set original_query_tag = get_current_query_tag() %}
     {% set original_query_tag_parsed = {} %}
     {% if original_query_tag %}
@@ -7,111 +7,21 @@
             {% set original_query_tag_parsed = fromjson(original_query_tag) %}
         {% endif %}
     {% endif %}
-    
-    {# The env_vars_to_query_tag_list should contain an environment variables list to construct query tag dict #}
-    {% set env_var_query_tags = {} %}
-    {% if var('env_vars_to_query_tag_list', '') %} {# Get a list of env vars from env_vars_to_query_tag_list variable to add additional query tags #}
-        {% for k in var('env_vars_to_query_tag_list') %}
-            {% set v = env_var(k, '') %}
-            {% do env_var_query_tags.update({k.lower(): v}) if v %}
-        {% endfor %}
+
+    {# Start with session-level query tag (preserves dbt_integration_id, dbt_integration_environment, etc.) #}
+    {% set query_tag = original_query_tag_parsed %}
+
+    {# is_incremental is only available at execution time, not in the query comment context #}
+    {# Guard with execute to prevent dbt parser from flagging seed hooks as node dependencies #}
+    {% if execute and model is not none and model.resource_type == 'model' %}
+        {% do query_tag.update(is_incremental=is_incremental()) %}
     {% endif %}
-    
-    {# Start with any model-configured dict #}
-    {% set query_tag = config.get('query_tag', default={}) %}
-    {% if query_tag is not mapping %}
-    {% do log("altimate-query-tag-warning: the query_tag config value of '{}' is not a mapping type, so is being ignored. If you'd like to add additional query tag information, use a mapping type instead, or remove it to avoid this message.".format(query_tag), True) %}
-    {% set query_tag = {} %} {# If the user has set the query tag config as a non mapping type, start fresh #}
-    {% endif %}
-    
-    {# Define session-level keys that should be preserved from original query tag #}
-    {% set session_level_keys = ['dbt_integration_id', 'dbt_integration_environment'] %}
-    
-    {# Extract only session-level information from original query tag #}
-    {% set session_query_tags = {} %}
-    {% for key in session_level_keys %}
-        {% if key in original_query_tag_parsed %}
-            {% do session_query_tags.update({key: original_query_tag_parsed[key]}) %}
-        {% endif %}
-    {% endfor %}
-    
-    {# Add session-level tags first #}
-    {% do query_tag.update(session_query_tags) %}
-    {% do query_tag.update(env_var_query_tags) %}
-    
-    {# Add node information if available - this will override any node-specific info from session #}
-    {% if model %}
-        {% do query_tag.update(
-            node_name=model.name,
-            node_alias=model.alias,
-            node_package_name=model.package_name,
-            node_database=model.database,
-            node_schema=model.schema,
-            node_id=model.unique_id,
-            node_resource_type=model.resource_type,
-            node_meta=model.config.meta,
-            node_tags=model.tags
-        ) %}
-        
-        {% if model.resource_type == 'model' %}
-            {% do query_tag.update(
-                materialized=model.config.materialized
-            ) %}
-        {% endif %}
-    {% endif %}
-    
-    {# Add extra parameters passed to the macro #}
-    {% do query_tag.update(extra) %}
-    
-    {# Add standard dbt information #}
-    {% do query_tag.update(
-        app='dbt',
-        dbt_snowflake_query_tags_version='1.0.2',
-        dbt_version=dbt_version,
-        project_name=project_name,
-        target_name=target.name,
-        target_database=target.database,
-        target_schema=target.schema,
-        invocation_id=invocation_id,
-        run_started_at=run_started_at.astimezone(modules.pytz.utc).isoformat(),
-        full_refresh=flags.FULL_REFRESH
-    ) %}
-    
-    {# Add additional Cloud information if available #}
-    {% if env_var('DBT_CLOUD_PROJECT_ID', False) %}
-        {% do query_tag.update(
-            dbt_cloud_project_id=env_var('DBT_CLOUD_PROJECT_ID')
-        ) %}
-    {% endif %}
-    {% if env_var('DBT_CLOUD_JOB_ID', False) %}
-        {% do query_tag.update(
-            dbt_cloud_job_id=env_var('DBT_CLOUD_JOB_ID')
-        ) %}
-    {% endif %}
-    {% if env_var('DBT_CLOUD_RUN_ID', False) %}
-        {% do query_tag.update(
-            dbt_cloud_run_id=env_var('DBT_CLOUD_RUN_ID')
-        ) %}
-    {% endif %}
-    
-    {% if thread_id %}
-        {% do query_tag.update(
-            thread_id=thread_id
-        ) %}
-    {% endif %}
-    
-    {# We have to bring is_incremental through here because its not available in the comment context #}
-    {% if model.resource_type == 'model' %}
-        {% do query_tag.update(
-            is_incremental=is_incremental()
-        ) %}
-    {% endif %}
-    
+
     {% set query_tag_json = tojson(query_tag) %}
-    
-    {# Check if the query tag exceeds 2000 characters, if so use original query tag #}
+
+    {# Validate against Snowflake's 2000-character query tag limit #}
     {% if query_tag_json and query_tag_json|length > 2000 %}
-        {% do log("altimate-query-tag-warning: The constructed query tag is too long ({} characters). Snowflake limits query tags to 2000 characters, so the original query tag will be preserved instead. This is possible if the model names are too large or the number of query_tags is too high. Query Tag json: {}".format(query_tag_json|length, query_tag_json), True) %}
+        {% do log("altimate-query-tag-warning: The constructed query tag is too long ({} characters). Snowflake limits query tags to 2000 characters, so the original query tag will be preserved instead.".format(query_tag_json|length), True) %}
         {% if original_query_tag %}
             {% do run_query("alter session set query_tag = '{}'".format(original_query_tag)) %}
         {% else %}
@@ -120,5 +30,6 @@
     {% else %}
         {% do run_query("alter session set query_tag = '{}'".format(query_tag_json)) %}
     {% endif %}
-    {{ return(original_query_tag)}}
+
+    {{ return(original_query_tag) }}
 {% endmacro %}

--- a/macros/unset_query_tag.sql
+++ b/macros/unset_query_tag.sql
@@ -1,9 +1,8 @@
 {% macro default__unset_query_tag(original_query_tag) -%}
     {% if original_query_tag %}
-        {{ log("Resetting query_tag to '" ~ original_query_tag ~ "'.") }}
-        {% do run_query("alter session set query_tag = '{}'".format(original_query_tag)) %}
+        {% set safe_tag = original_query_tag | replace("'", "''") %}
+        {% do run_query("alter session set query_tag = '{}'".format(safe_tag)) %}
     {% else %}
-        {{ log("No original query_tag, unsetting parameter.") }}
         {% do run_query("alter session unset query_tag") %}
     {% endif %}
 {% endmacro %}

--- a/macros/unset_query_tag.sql
+++ b/macros/unset_query_tag.sql
@@ -1,0 +1,9 @@
+{% macro default__unset_query_tag(original_query_tag) -%}
+    {% if original_query_tag %}
+        {{ log("Resetting query_tag to '" ~ original_query_tag ~ "'.") }}
+        {% do run_query("alter session set query_tag = '{}'".format(original_query_tag)) %}
+    {% else %}
+        {{ log("No original query_tag, unsetting parameter.") }}
+        {% do run_query("alter session unset query_tag") %}
+    {% endif %}
+{% endmacro %}


### PR DESCRIPTION
## Summary

- **Adds `get_query_comment` macro**: Comprehensive metadata (node info, dbt context, cloud metadata, refs, raw code hash) appended to every SQL statement as a comment — no character limit
- **Slims down `set_query_tag`**: Query tag now only contains session-level keys (`dbt_integration_id`, `dbt_integration_environment`) and `is_incremental` — well under Snowflake's 2000-char limit
- **Adds `unset_query_tag` macro**: Properly restores the original session query tag after model execution
- **Version bump to 2.0.0**: Breaking change in what's stored in query tags vs comments

### Why

Query tags frequently exceeded Snowflake's 2000-character limit when model names, meta, or tags were large. This caused the tag to fall back to the original (losing all enrichment). By moving comprehensive metadata to query comments (no limit) and keeping query tags lean, we eliminate the 2000-char issue entirely.

### E2E Verified in Snowflake

**Query Tag** (lean, ~95 chars):
```json
{"dbt_integration_id": 99, "dbt_integration_environment": "DEV", "is_incremental": true}
```

**Query Comment** (comprehensive, appended to SQL):
```json
{"app": "dbt", "dbt_snowflake_query_tags_version": "2.0.0", "dbt_version": "1.11.6", "project_name": "jaffle_shop", "target_name": "dev", "target_database": "analytics", "target_schema": "public", "invocation_id": "...", "run_started_at": "2026-03-11T22:41:54...", "full_refresh": false, "node_name": "test_incremental_tags", "node_alias": "test_incremental_tags", "node_package_name": "jaffle_shop", "node_original_file_path": "models/test_incremental_tags.sql", "materialized": "incremental", "node_refs": [], "raw_code_hash": "d4e412acd154df35d62cc1b6b000adc8"}
```

## Test plan

- [x] E2E tested with jaffle-shop against Snowflake (account: `ejjkbko-fub20041`)
- [x] Verified query tags appear in `QUERY_TAG` column of `information_schema.query_history`
- [x] Verified query comments are appended to SQL in `QUERY_TEXT` column
- [x] Verified `is_incremental: false` for first run, `is_incremental: true` for subsequent incremental runs
- [x] Verified `dbt seed` works without "seeds cannot depend on other nodes" parsing errors
- [x] Verified `dbt run` succeeds for both table and incremental materializations
- [ ] Test with dbt Cloud (extended attributes for `query_tag`)
- [ ] Test with large model names/meta to confirm query tags stay under 2000 chars

🤖 Generated with [Claude Code](https://claude.com/claude-code)